### PR TITLE
Fix mapping to multiple files and original filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,8 +44,8 @@ function merge(oldMap, newMap) {
         line: m.generatedLine,
         column: m.generatedColumn
       },
-      source: m.source,
-      name: m.name
+      source: origPosInOldMap.source,
+      name: origPosInOldMap.name
     })
   })
 

--- a/index.js
+++ b/index.js
@@ -50,8 +50,11 @@ function merge(oldMap, newMap) {
   })
 
   var mergedMap = JSON.parse(mergedMapGenerator.toString())
-  mergedMap.sources = oldMap.sources
-  mergedMap.sourcesContent = oldMap.sourcesContent
+
+  mergedMap.sourcesContent = mergedMap.sources.map(function (source) {
+    return oldMapConsumer.sourceContentFor(source)
+  })
+
   mergedMap.sourceRoot = oldMap.sourceRoot
 
   return mergedMap


### PR DESCRIPTION
Source maps should always point to the original source files and variable/function names